### PR TITLE
3rd Proposal for Generalising Uint serialisation and merkleisation

### DIFF
--- a/src/dafny/merkle/Merkleise.dfy
+++ b/src/dafny/merkle/Merkleise.dfy
@@ -64,13 +64,17 @@ include "../beacon/helpers/Crypto.dfy"
      *              (reference: Phase 0 spec - deposit contract).
      */
     function method chunkCount(s: Serialisable): nat
-        requires || typeOf(s) in {Bool_,Bitlist_,Bytes32_}
-                 || exists n:nat :: typeOf(s) == Uint_(n)
+        requires typeOf(s) in {Bool_, Uint8_, Uint16_, Uint32_, Uint64_, Uint128_, Uint256_, Bitlist_,Bytes32_}
         ensures 0 <= chunkCount(s) // add upper limit ???
     {
         match s
             case Bool(b) => chunkCountBool(b)
-            case Uint(n) => chunkCountUint(s)
+            case Uint8(_) => chunkCountUint(s)
+            case Uint16(_) => chunkCountUint(s)
+            case Uint32(_) => chunkCountUint(s)
+            case Uint64(_) => chunkCountUint(s)
+            case Uint128(_) => chunkCountUint(s)
+            case Uint256(_) => chunkCountUint(s)
             case Bitlist(xl) => chunkCountBitlist(xl) 
             case Bytes32(bs) => chunkCountBytes32(bs)
     } 
@@ -275,12 +279,16 @@ include "../beacon/helpers/Crypto.dfy"
     //     else toChunks(serialiseObjects(s))
     // }
     function method pack(s: Serialisable): seq<chunk>
-        requires || typeOf(s) in {Bool_,Bytes32_}
-                 || exists n:nat :: typeOf(s) == Uint_(n)
+        requires typeOf(s) in {Bool_,Bytes32_, Uint8_, Uint16_, Uint32_, Uint64_, Uint128_, Uint256_}
     {
         match s
             case Bool(b) => packBool(b)
-            case Uint(n) => packUint(s)
+            case Uint8(_) => packUint(s)
+            case Uint16(_) => packUint(s)
+            case Uint32(_) => packUint(s)
+            case Uint64(_) => packUint(s)
+            case Uint128(_) => packUint(s)
+            case Uint256(_) => packUint(s)
             case Bytes32(bs) => packBytes32(bs)
     } 
 
@@ -293,10 +301,10 @@ include "../beacon/helpers/Crypto.dfy"
         toChunks(serialise(Bool(b)))
     }
 
-    function method packUint(n: Uint): seq<chunk>
-        ensures |packUint(n)| == 1
+    function method packUint(s: Uint): seq<chunk>
+        ensures |packUint(s)| == 1
     {
-        toChunks(serialise(n))
+        toChunks(serialise(s))
     }
 
     function method packBytes32(bs: Seq32Byte): seq<chunk>
@@ -569,6 +577,16 @@ include "../beacon/helpers/Crypto.dfy"
             case Bool(_) => merkleise(pack(s), -1)
 
             case Uint(_) => merkleise(pack(s), -1)
+
+            case Uint16(_) => merkleise(pack(s), -1)
+
+            case Uint32(_) => merkleise(pack(s), -1)
+
+            case Uint64(_) => merkleise(pack(s), -1)
+
+            case Uint128(_) => merkleise(pack(s), -1)
+
+            case Uint256(_) => merkleise(pack(s), -1)          
 
             case Bitlist(xl) => bitlistLimit(s);
                                 mixInLength(merkleise(bitfieldBytes(xl), chunkCount(s)), |xl|)  

--- a/src/dafny/ssz/IntSeDes.dfy
+++ b/src/dafny/ssz/IntSeDes.dfy
@@ -32,20 +32,7 @@ module IntSeDes {
     import opened Math__power_s
 
     //  Uintk serialisation and deserielisation.
-
-    function method uintToBytes(n: Uint) : seq<byte> 
-    ensures |uintToBytes(n)| == n.n.byteLength
-    {
-        int_to_bytes(n.n.n as nat,n.n.byteLength)
-    }
-
-    function method byteToUint(bs: bytes) :  Uint
-    requires 1 <= |bs| <= 32
-    {
-        lemmaPower2IsMonotnoic(|bs|*8,256);
-        Uint(Uint256WithByteLength(bytes_to_int(bs) as uint256,|bs|))
-    }    
-    
+      
     /**
      * Computes the little endian serialisation of a `uint64` value
      *
@@ -139,6 +126,12 @@ module IntSeDes {
                             (s[0] as nat)/power2(8) + bytes_to_int(s[1..]);
                             bytes_to_int(s[1..]);
                         }
+
+                        calc {
+                            (s[0] as nat + bytes_to_int(s[1..])*power2(8)) % power2(8);
+                            s[0] as nat % power2(8);
+                            s[0] as nat;
+                        }
                     }
                 [s[0]] + int_to_bytes(bytes_to_int(s[1..]),(|s|-1));
                 // via induction
@@ -148,16 +141,4 @@ module IntSeDes {
         }
     }     
 
-    lemma lemmaBytesToUintIsTheInverseOfUintToBytes(n:Uint)
-    ensures byteToUint(uintToBytes(n)) == n
-    {
-        lemmaBytesToIntIsTheInverseOfIntToBytes(n.n.n as nat,n.n.byteLength);
-    }
-
-    lemma lemmaUintToBytesIsTheInverseOfBytesToUint(bs:bytes)
-    requires 1 <= |bs| <= 32
-    ensures uintToBytes(byteToUint(bs)) == bs
-    {
-        lemmaIntToBytesIsTheInverseOfBytesToInt(bs);
-    }
 }

--- a/src/dafny/ssz/IntSeDes.dfy
+++ b/src/dafny/ssz/IntSeDes.dfy
@@ -1,9 +1,9 @@
 /*
  * Copyright 2020 ConsenSys AG.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
+ * Licensed under the Apache License, Version 2.n (the "License"); you may 
  * not use this file except in compliance with the License. You may obtain 
- * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.n
  *
  * Unless required by applicable law or agreed to in writing, software dis-
  * tributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
@@ -13,7 +13,10 @@
  */
 
 include "../utils/NativeTypes.dfy"
+include "../utils/NonNativeTypes.dfy"
 include "../utils/Eth2Types.dfy"
+include "../utils/MathHelpers.dfy"
+include "../libraries/integers/power.i.dfy"
 
 /**
  *  Integers serialisation, desrialisation.
@@ -22,26 +25,139 @@ include "../utils/Eth2Types.dfy"
 module IntSeDes {
 
     import opened NativeTypes
+    import opened NonNativeTypes
     import opened Eth2Types
+    import opened MathHelpers
+    import opened Math__power_i
+    import opened Math__power_s
 
     //  Uintk serialisation and deserielisation.
 
-    /** Uint8. */
-    function method uint8ToBytes(n: uint8) : seq<byte> 
-        ensures |uint8ToBytes(n)| == 1
+    function method uintToBytes(n: Uint) : seq<byte> 
+    ensures |uintToBytes(n)| == n.n.byteLength
     {
-        [n as byte]
-    }
- 
-    function method byteToUint8(b: byte) : uint8
-    {
-        (b as uint8)
+        int_to_bytes(n.n.n as nat,n.n.byteLength)
     }
 
-    /** Encode/decode Uint8 yields Identity. */
-    lemma uint8AsBytesInvolutive(n : uint8) 
-        ensures byteToUint8(uint8ToBytes(n)[0]) == n
-    {   //  Thanks Dafny
+    function method byteToUint(bs: bytes) :  Uint
+    requires 1 <= |bs| <= 32
+    {
+        lemmaPower2IsMonotnoic(|bs|*8,256);
+        Uint(Uint256WithByteLength(bytes_to_int(bs) as uint256,|bs|))
+    }    
+    
+    /**
+     * Computes the little endian serialisation of a `uint64` value
+     *
+     * @param n        A `uint64` value
+     * @param length   Length of the serialisation.
+     * @requires       n < power(256,length) 
+     *                 n <= 8
+     *
+     * @returns        The `length`-byte little endian serialisation of `n`
+     *
+     */
+    function method int_to_bytes(n: nat, length: nat) : bytes
+    requires n as nat < power2(length * 8)
+    ensures |int_to_bytes(n,length)| == length as int
+    {
+        if(length == 0) then
+            []
+        else
+            [(n % power2(8)) as uint8] +
+                assert power2(length * 8) == power2((length-1)*8) * power2(8) by {
+                    productRulePower2((length-1)*8,8);
+                }
+            int_to_bytes(n / power2(8), length-1)
     }
 
+    /**
+     * Deserialise a sequence of bytes to `uint64` using little endian
+     * interpretation
+     *
+     * @param s Sequence of bytes. Must be no longer than 8 bytes.
+     * 
+     * @returns A `uint64` value corresponding to the little endian
+     * deserialisation of `s`
+     */
+    function method bytes_to_int(s: bytes):nat
+    ensures bytes_to_int(s)  < power2(|s|*8)
+    {
+        if(|s| == 0) then
+            0
+        else
+            calc ==> {
+                 bytes_to_int(s[1..]) <= power2((|s|-1)*8) - 1;
+                    {
+                        productRulePower2((|s|-1)*8,8);
+                    }
+                 power2(8) * bytes_to_int(s[1..]) <= power2(|s|*8) - power2(8);
+                 s[0] as nat + bytes_to_int(s[1..])*power2(8) < power2(|s|*8);
+            }
+            s[0] as nat + bytes_to_int(s[1..])*power2(8)
+    }
+
+    /** `bytes_to_int` is the inverse of `int_to_bytes` */
+    lemma lemmaBytesToIntIsTheInverseOfIntToBytes(n: nat, length: nat)
+    requires int_to_bytes.requires(n,length)
+    ensures bytes_to_int(int_to_bytes(n,length)) == n 
+    {
+        if(length == 0)
+        {
+
+        }
+        else
+        {
+            calc == {
+                bytes_to_int(int_to_bytes(n,length));
+                {           
+                    productRulePower2((length-1)*8,8);
+                }
+                bytes_to_int( [(n % power2(8)) as uint8] + int_to_bytes(n / power2(8), length-1));
+                (n % power2(8)) + bytes_to_int(int_to_bytes(n / power2(8), length-1))*power2(8);
+                (n % power2(8)) + (n / power2(8)) * power2(8);
+            }
+        }
+    }
+
+    lemma lemmaIntToBytesIsTheInverseOfBytesToInt(s: bytes)
+    requires bytes_to_int.requires(s)
+    ensures int_to_bytes(bytes_to_int(s),|s|) == s 
+    { 
+        if(|s|==0)
+        {
+            // Thanks Dafny
+        }
+        else
+        {
+            calc == {
+                int_to_bytes(bytes_to_int(s),|s|);
+                int_to_bytes(s[0] as nat + bytes_to_int(s[1..])*power2(8),|s|);
+                    {
+                        calc {
+                            (s[0] as nat + bytes_to_int(s[1..])*power2(8))/power2(8);
+                            (s[0] as nat)/power2(8) + bytes_to_int(s[1..]);
+                            bytes_to_int(s[1..]);
+                        }
+                    }
+                [s[0]] + int_to_bytes(bytes_to_int(s[1..]),(|s|-1));
+                // via induction
+                [s[0]] + s[1..];
+                s;
+            }
+        }
+    }     
+
+    lemma lemmaBytesToUintIsTheInverseOfUintToBytes(n:Uint)
+    ensures byteToUint(uintToBytes(n)) == n
+    {
+        lemmaBytesToIntIsTheInverseOfIntToBytes(n.n.n as nat,n.n.byteLength);
+    }
+
+    lemma lemmaUintToBytesIsTheInverseOfBytesToUint(bs:bytes)
+    requires 1 <= |bs| <= 32
+    ensures uintToBytes(byteToUint(bs)) == bs
+    {
+        lemmaIntToBytesIsTheInverseOfBytesToInt(bs);
+    }
 }

--- a/src/dafny/utils/Eth2Types.dfy
+++ b/src/dafny/utils/Eth2Types.dfy
@@ -13,6 +13,7 @@
  */
 
 include "NativeTypes.dfy"
+include "NonNativeTypes.dfy"
 include "../utils/Helpers.dfy"
 include "../utils/MathHelpers.dfy"
 
@@ -24,6 +25,7 @@ include "../utils/MathHelpers.dfy"
 module Eth2Types {
 
     import opened NativeTypes
+    import opened NonNativeTypes
     import opened Helpers
     import opened MathHelpers
 
@@ -41,6 +43,16 @@ module Eth2Types {
     type Seq32Byte = x:seq<byte> | |x| == 32 witness timeSeq(0 as byte, 32)
     // SEQ_EMPTY_32_BYTES
 
+    datatype Uint256WithByteLength = Uint256WithByteLength(n:uint256,byteLength:nat)
+
+    type CorrectUint256WithByteLength = u:Uint256WithByteLength |   && u.n as nat < power2(u.byteLength * 8)
+                                                                    && 1 <= u.byteLength <= 32
+                                                                    witness Uint256WithByteLength(0,1)
+
+    // type Uint256WithByteLength = x:(uint256,nat) | && x.0 as nat < power2(x.1 * 8)
+    //                                            && 1 <= x.1 <= 32 
+    //                                            witness (0,1)
+
     /** Create type synonym for a chunk */
     type chunk = Seq32Byte
 
@@ -49,11 +61,102 @@ module Eth2Types {
 
     /** The serialisable objects. */
     datatype Serialisable = 
-            Uint8(n: uint8)
+            Uint(n: CorrectUint256WithByteLength)
         |   Bool(b: bool)
         |   Bitlist(xl: seq<bool>)
         |   Bytes32(bs: Seq32Byte)
         |   Container(fl: seq<Serialisable>)
+
+    type Uint = s:Serialisable |    s.Uint?
+                                    witness Uint(Uint256WithByteLength(0,1))
+    
+
+    // The assert is required to for Dafny to verify that the provided witness
+    // respects the constraint imposed by the existential quantifier
+    type Uint8 = s:Uint |   assert  Equal<uint256>(0,0);
+                            && exists x:uint8 :: Equal<uint256>(s.n.n, x as uint256)
+                            && s.n.byteLength == 1
+                            witness Uint(Uint256WithByteLength(0,1))
+
+    type Uint16 = s:Uint |  assert  Equal<uint256>(0,0);
+                            && exists x:uint16 :: Equal<uint256>(s.n.n, x as uint256)
+                            && s.n.byteLength == 2
+                            witness Uint(Uint256WithByteLength(0,2))   
+
+    type Uint32 = s:Uint |  assert  Equal<uint256>(0,0);
+                            && exists x:uint32 :: Equal<uint256>(s.n.n, x as uint256)
+                            && s.n.byteLength == 4
+                            witness Uint(Uint256WithByteLength(0,4))
+ 
+
+    type Uint64 = s:Uint |  assert  Equal<uint256>(0,0);
+                            // castUin64ToUint256 is probaly only required
+                            // becaue uint256 is currently defined using power2
+                            && exists x:uint64 :: Equal<uint256>(s.n.n, castUin64ToUint256(x))
+                            && s.n.byteLength == 8
+                            witness Uint(Uint256WithByteLength(castUin64ToUint256(0),8))
+
+    type Uint128 = s:Uint | assert  Equal<uint256>(0,0);
+                            // castUi1284ToUint256 is probaly only required
+                            // becaue uint256 is currently defined using power2
+                            && exists x:uint128 :: Equal<uint256>(s.n.n, castUin128ToUint256(x))
+                            && s.n.byteLength == 16
+                            witness Uint(Uint256WithByteLength(castUin128ToUint256(0),16))   
+
+    type Uint256 = s:Uint |  assert  Equal<uint256>(0,0);
+                            && exists x:uint256 :: Equal<uint256>(s.n.n, x as uint256)
+                            && s.n.byteLength == 32
+                            witness Uint(Uint256WithByteLength(0,32))                                                                                                           
+
+    // Strangely, if the prefix "make" is dropped by the following functions,
+    // then inside this module Dafny is still able to correctly associate when,
+    // for example, Uint8 is used as a type or as function, however outside this
+    // module Dafny appears to consider Uint8 only a type and not a function.
+    function method makeUint8(a:uint8): Uint8
+    ensures makeUint8(a).n.n == a as uint256;
+    {
+        assert Equal<uint256>(a as uint256, a as uint256);
+        Uint(Uint256WithByteLength(a as uint256,1))
+    }
+
+    function method makeUint16(a:uint16): Uint16
+    ensures makeUint16(a).n.n == a as uint256;
+    {
+        assert Equal<uint256>(a as uint256, a as uint256);
+        assert a as nat < power2(16);
+        Uint(Uint256WithByteLength(a as uint256,2))
+    }    
+
+    function method makeUint32(a:uint32): Uint32
+    ensures makeUint32(a).n.n == a as uint256;
+    {
+        assert Equal<uint256>(a as uint256, a as uint256);
+        assert a as nat < power2(32);
+        Uint(Uint256WithByteLength(a as uint256,4))
+    }
+
+    function method makeUint64(a:uint64): Uint64
+    ensures makeUint64(a).n.n == castUin64ToUint256(a);
+    {
+        assert Equal<uint256>(castUin64ToUint256(a),castUin64ToUint256(a));
+        UpperBoundForUint64(a);
+        Uint(Uint256WithByteLength(a as uint256,8))
+    }  
+
+    function method makeUint128(a:uint128): Uint128
+    ensures makeUint128(a).n.n == castUin128ToUint256(a);
+    {
+        assert Equal<uint256>(castUin128ToUint256(a),castUin128ToUint256(a));
+        UpperBoundForUint128(a);
+        Uint(Uint256WithByteLength(a as uint256,16))
+    } 
+
+    function method makeUint256(a:uint256): Uint256
+    ensures makeUint256(a).n.n == a;
+    {
+        assert Equal<uint256>(a as uint256, a as uint256);
+        Uint(Uint256WithByteLength(a,32))
+    }  
 
     /** The type `Bytes32` corresponding to a Serialisable built using the
      * `Bytes32` constructor 
@@ -72,7 +175,9 @@ module Eth2Types {
      *  and also to prove some lemmas.
      */
     datatype Tipe =
-            Uint8_
+            // The Tipe Uint_ requires the byteLength parameter as Uint_ of
+            // different lenght are different types
+            Uint_(byteLength:nat)
         |   Bool_
         |   Bitlist_
         |   Bytes32_
@@ -88,7 +193,7 @@ module Eth2Types {
             match s 
                 case Bool(_) => Bool_
         
-                case Uint8(_) => Uint8_
+                case Uint(n) => Uint_(n.byteLength)
 
                 case Bitlist(_) => Bitlist_
 

--- a/src/dafny/utils/Eth2Types.dfy
+++ b/src/dafny/utils/Eth2Types.dfy
@@ -61,102 +61,26 @@ module Eth2Types {
 
     /** The serialisable objects. */
     datatype Serialisable = 
-            Uint(n: CorrectUint256WithByteLength)
+            Uint8(n8: uint8)
+        |   Uint16(n16: uint16)
+        |   Uint32(n32: uint32)
+        |   Uint64(n64: uint64)
+        |   Uint128(n128: uint128)
+        |   Uint256(n256 :uint256)
         |   Bool(b: bool)
         |   Bitlist(xl: seq<bool>)
         |   Bytes32(bs: Seq32Byte)
         |   Container(fl: seq<Serialisable>)
 
-    type Uint = s:Serialisable |    s.Uint?
-                                    witness Uint(Uint256WithByteLength(0,1))
+    type Uint = s:Serialisable |    || s.Uint8?
+                                    || s.Uint16?
+                                    || s.Uint32?
+                                    || s.Uint64?
+                                    || s.Uint128?
+                                    || s.Uint256?
+                                    witness Uint8(0)
     
 
-    // The assert is required to for Dafny to verify that the provided witness
-    // respects the constraint imposed by the existential quantifier
-    type Uint8 = s:Uint |   assert  Equal<uint256>(0,0);
-                            && exists x:uint8 :: Equal<uint256>(s.n.n, x as uint256)
-                            && s.n.byteLength == 1
-                            witness Uint(Uint256WithByteLength(0,1))
-
-    type Uint16 = s:Uint |  assert  Equal<uint256>(0,0);
-                            && exists x:uint16 :: Equal<uint256>(s.n.n, x as uint256)
-                            && s.n.byteLength == 2
-                            witness Uint(Uint256WithByteLength(0,2))   
-
-    type Uint32 = s:Uint |  assert  Equal<uint256>(0,0);
-                            && exists x:uint32 :: Equal<uint256>(s.n.n, x as uint256)
-                            && s.n.byteLength == 4
-                            witness Uint(Uint256WithByteLength(0,4))
- 
-
-    type Uint64 = s:Uint |  assert  Equal<uint256>(0,0);
-                            // castUin64ToUint256 is probaly only required
-                            // becaue uint256 is currently defined using power2
-                            && exists x:uint64 :: Equal<uint256>(s.n.n, castUin64ToUint256(x))
-                            && s.n.byteLength == 8
-                            witness Uint(Uint256WithByteLength(castUin64ToUint256(0),8))
-
-    type Uint128 = s:Uint | assert  Equal<uint256>(0,0);
-                            // castUi1284ToUint256 is probaly only required
-                            // becaue uint256 is currently defined using power2
-                            && exists x:uint128 :: Equal<uint256>(s.n.n, castUin128ToUint256(x))
-                            && s.n.byteLength == 16
-                            witness Uint(Uint256WithByteLength(castUin128ToUint256(0),16))   
-
-    type Uint256 = s:Uint |  assert  Equal<uint256>(0,0);
-                            && exists x:uint256 :: Equal<uint256>(s.n.n, x as uint256)
-                            && s.n.byteLength == 32
-                            witness Uint(Uint256WithByteLength(0,32))                                                                                                           
-
-    // Strangely, if the prefix "make" is dropped by the following functions,
-    // then inside this module Dafny is still able to correctly associate when,
-    // for example, Uint8 is used as a type or as function, however outside this
-    // module Dafny appears to consider Uint8 only a type and not a function.
-    function method makeUint8(a:uint8): Uint8
-    ensures makeUint8(a).n.n == a as uint256;
-    {
-        assert Equal<uint256>(a as uint256, a as uint256);
-        Uint(Uint256WithByteLength(a as uint256,1))
-    }
-
-    function method makeUint16(a:uint16): Uint16
-    ensures makeUint16(a).n.n == a as uint256;
-    {
-        assert Equal<uint256>(a as uint256, a as uint256);
-        assert a as nat < power2(16);
-        Uint(Uint256WithByteLength(a as uint256,2))
-    }    
-
-    function method makeUint32(a:uint32): Uint32
-    ensures makeUint32(a).n.n == a as uint256;
-    {
-        assert Equal<uint256>(a as uint256, a as uint256);
-        assert a as nat < power2(32);
-        Uint(Uint256WithByteLength(a as uint256,4))
-    }
-
-    function method makeUint64(a:uint64): Uint64
-    ensures makeUint64(a).n.n == castUin64ToUint256(a);
-    {
-        assert Equal<uint256>(castUin64ToUint256(a),castUin64ToUint256(a));
-        UpperBoundForUint64(a);
-        Uint(Uint256WithByteLength(a as uint256,8))
-    }  
-
-    function method makeUint128(a:uint128): Uint128
-    ensures makeUint128(a).n.n == castUin128ToUint256(a);
-    {
-        assert Equal<uint256>(castUin128ToUint256(a),castUin128ToUint256(a));
-        UpperBoundForUint128(a);
-        Uint(Uint256WithByteLength(a as uint256,16))
-    } 
-
-    function method makeUint256(a:uint256): Uint256
-    ensures makeUint256(a).n.n == a;
-    {
-        assert Equal<uint256>(a as uint256, a as uint256);
-        Uint(Uint256WithByteLength(a,32))
-    }  
 
     /** The type `Bytes32` corresponding to a Serialisable built using the
      * `Bytes32` constructor 
@@ -175,9 +99,12 @@ module Eth2Types {
      *  and also to prove some lemmas.
      */
     datatype Tipe =
-            // The Tipe Uint_ requires the byteLength parameter as Uint_ of
-            // different lenght are different types
-            Uint_(byteLength:nat)
+            Uint8_
+        |   Uint16_
+        |   Uint32_
+        |   Uint64_
+        |   Uint128_
+        |   Uint256_
         |   Bool_
         |   Bitlist_
         |   Bytes32_
@@ -194,6 +121,16 @@ module Eth2Types {
                 case Bool(_) => Bool_
         
                 case Uint(n) => Uint_(n.byteLength)
+
+                case Uint16(_) => Uint16_
+
+                case Uint32(_) => Uint32_
+
+                case Uint64(_) => Uint64_
+
+                case Uint128(_) => Uint128_
+
+                case Uint256(_) => Uint256_
 
                 case Bitlist(_) => Bitlist_
 

--- a/src/dafny/utils/Helpers.dfy
+++ b/src/dafny/utils/Helpers.dfy
@@ -332,5 +332,14 @@ module Helpers {
         ensures flatten(s)[flattenLength(s[..i]) + j] == s[i][j]
     {
         flattenOneToOneChunk(s,i,flattenLength(s[..i]));
+    }    
+
+    /** 
+     * Predicate to be used in quantifier expressions that need to be triggered
+     * on equality check
+     */
+    predicate Equal<T(==)>(a:T,b:T)
+    {
+        a == b
     }        
 }

--- a/src/dafny/utils/MathHelpers.dfy
+++ b/src/dafny/utils/MathHelpers.dfy
@@ -18,7 +18,7 @@
 module MathHelpers {
 
     /** Define 2^n. */
-    function power2(n : nat): nat 
+    function method power2(n : nat): nat 
         ensures power2(n) >= 1
         ensures n >= 1 ==> power2(n) >= 2 
 
@@ -26,6 +26,11 @@ module MathHelpers {
     {
         if n == 0 then 1 else 2 * power2(n - 1)
     }
+
+    lemma lemmaPower2IsMonotnoic(e1:nat,e2:nat)
+    requires e1 <= e2
+    ensures power2(e1) <= power2(e2)
+    { }
 
     /** Get the next power of two.
      *

--- a/src/dafny/utils/NonNativeTypes.dfy
+++ b/src/dafny/utils/NonNativeTypes.dfy
@@ -30,5 +30,49 @@
     * positive numbers that can be expressed in binary form with no more than 256
     * bits 
     */
-    newtype uint256 = i:int | 0 <= i < power2(256)       
+    newtype uint256 = i:int | 0 <= i < power2(256)     
+
+
+    // The foollowing functions and lemmas are used by the Eth2Types module and
+    // are probably only requried because we currently define uint128 and
+    // uint256 uisng power2
+    function method castUin64ToUint256(x:uint64): uint256
+    ensures castUin64ToUint256(x) as nat < 0x10000000000000000
+    ensures castUin64ToUint256(x) as uint64 == x
+    {
+        UpperBoundForUint64(x);
+        lemmaPower2IsMonotnoic(64,256);
+        x as uint256
+    }
+
+    lemma UpperBoundForUint64(x:uint64)
+    ensures x as nat < power2(64)
+    {
+        calc ==>
+        {
+            0x100000000 == power2(32); 
+            0x10000000000000000 == power2(64);  
+        }
+    }
+
+    function method castUin128ToUint256(x:uint128): uint256
+    ensures castUin128ToUint256(x) as nat < power2(128)
+    ensures castUin128ToUint256(x) as uint128 == x    
+    {
+        UpperBoundForUint128(x);
+        lemmaPower2IsMonotnoic(128,256);
+        x as uint256
+    }   
+
+    lemma UpperBoundForUint128(x:uint128)
+    ensures x as nat < power2(128)
+    {
+        calc ==>
+        {
+            0x100000000 == power2(32); 
+            0x10000000000000000 == power2(64);  
+                { productRulePower2(64,64); }
+            0x100000000000000000000000000000000 == power2(128);
+        }
+    }     
  }

--- a/test/dafny/merkle/Merkleise.test.dfy
+++ b/test/dafny/merkle/Merkleise.test.dfy
@@ -45,7 +45,7 @@ include "../../../src/dafny/merkle/Merkleise.dfy"
             TestItem(
                 "Count chunks for serialised uint8(5) is 1",
                 () => chunkCount(
-                    makeUint8(5 as uint8)
+                    Uint8(5 as uint8)
                     ) == 1 
             ),
             TestItem(
@@ -63,7 +63,7 @@ include "../../../src/dafny/merkle/Merkleise.dfy"
          var r2 := [
             TestItem(
                 "Right pad with zeros 127 has size 32",
-                () => |rightPadZeros(serialise(makeUint8(127)))| == 32 
+                () => |rightPadZeros(serialise(Uint8(127)))| == 32 
             )
             // TestItem(
             //     "Count chunks for serialised bool true is 1",

--- a/test/dafny/merkle/Merkleise.test.dfy
+++ b/test/dafny/merkle/Merkleise.test.dfy
@@ -44,11 +44,13 @@ include "../../../src/dafny/merkle/Merkleise.dfy"
         var rb := [
             TestItem(
                 "Count chunks for serialised uint8(5) is 1",
-                () => chunkCount(Uint8(5, Uint8_)) == 1 
+                () => chunkCount(
+                    makeUint8(5 as uint8)
+                    ) == 1 
             ),
             TestItem(
                 "Count chunks for serialised bool true is 1",
-                () => chunkCount(Bool(true, Bool_)) == 1 
+                () => chunkCount(Bool(true)) == 1 
             )
         ];
 
@@ -61,7 +63,7 @@ include "../../../src/dafny/merkle/Merkleise.dfy"
          var r2 := [
             TestItem(
                 "Right pad with zeros 127 has size 32",
-                () => |rightPadZeros(serialise(Uint8(127, Uint8_)))| == 32 
+                () => |rightPadZeros(serialise(makeUint8(127)))| == 32 
             )
             // TestItem(
             //     "Count chunks for serialised bool true is 1",


### PR DESCRIPTION
This PR is an alternative proposal to the one of PR #27 for generalising the serialisation and merkleisation of uints.

The main difference between this PR and PR #27 is that in this PR each uint[8, 16, 32, 64, 128, 256] type as its own `Serialisable` constructor.

[Here](https://github.com/saltiniroberto/eth2.0-dafny/compare/generalise_Uint...saltiniroberto:generalise_Uint_with_specific_constructors) is a code-level comparison between this PR and PR #27.

Here is my personal view on the pros and cons of each solution.

**Pros of PR #27**
- Lower likelihood of introducing specification errors

**Pros of this PR**
- Eth2Types module is much simpler

**Note:** Both solutions have roughly the same number of LoC based on the number of additions and deletions showed [here](https://github.com/saltiniroberto/eth2.0-dafny/compare/generalise_Uint...saltiniroberto:generalise_Uint_with_specific_constructors).